### PR TITLE
feat: add CRT-style ripple effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,16 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <!-- SVG фильтр ряби -->
+    <svg width="0" height="0" style="position:absolute">
+        <filter id="crt-warp" x="-20%" y="-20%" width="140%" height="140%" filterUnits="objectBoundingBox">
+            <feTurbulence id="noise" type="fractalNoise" baseFrequency="0.001 1.0" numOctaves="1" seed="2" result="n"/>
+            <feDisplacementMap id="disp" in="SourceGraphic" in2="n" xChannelSelector="R" yChannelSelector="G" scale="10"/>
+        </filter>
+    </svg>
     <div class="pip-boy">
         <div class="screen">
+            <div class="tear" id="tear"></div>
             <img id="current-image" src="" alt="Vault-Tec Instruction" style="display: none;">
             <div id="loading">Ожидайте...</div>
             <div class="scanlines"></div>

--- a/script.js
+++ b/script.js
@@ -173,3 +173,41 @@ fetch(imagesApiUrl)
         loadingElement.textContent = 'Error loading images or content';
         counterElement.textContent = 'Error';
     });
+
+// Эффект ряби с использованием шумового фильтра
+(function () {
+    const screen = document.querySelector('.screen');
+    const tear = document.getElementById('tear');
+    const noise = document.getElementById('noise');
+    const disp = document.getElementById('disp');
+
+    const RIPPLE_MS = 160;
+    const minDelay = 4000;
+    const maxDelay = 8000;
+
+    function random(min, max) { return Math.random() * (max - min) + min; }
+
+    function triggerRipple() {
+        const y = Math.round(random(8, 92));
+        tear.style.setProperty('--tearY', y + '%');
+
+        const baseX = random(0.0005, 0.1020).toFixed(4);
+        const baseY = random(0.85, 1.85).toFixed(2);
+        noise.setAttribute('baseFrequency', `${baseX} ${baseY}`);
+
+        const scale = Math.round(random(8, 18));
+        disp.setAttribute('scale', String(scale));
+
+        screen.classList.add('ripple');
+        setTimeout(() => screen.classList.remove('ripple'), RIPPLE_MS);
+
+        scheduleNext();
+    }
+
+    function scheduleNext() {
+        const t = Math.round(random(minDelay, maxDelay));
+        setTimeout(triggerRipple, t);
+    }
+
+    scheduleNext();
+})();

--- a/styles.css
+++ b/styles.css
@@ -83,6 +83,34 @@ body {
     animation: distort 0.5s ease-in-out forwards;
 }
 
+/* Полоска-рывок и эффект ряби */
+.tear {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    top: var(--tearY, 40%);
+    height: 12px;
+    opacity: 0;
+    pointer-events: none;
+    background: linear-gradient(to bottom, transparent 0%, rgba(255, 255, 255, 0.09) 50%, transparent 100%);
+    mix-blend-mode: screen;
+    z-index: 3;
+}
+
+.screen.ripple .tear {
+    opacity: .85;
+    animation: tearShift 120ms ease-in-out 3 alternate;
+}
+
+@keyframes tearShift {
+    from { transform: translateX(-6px); }
+    to { transform: translateX(6px); }
+}
+
+.screen.ripple {
+    filter: url(#crt-warp);
+}
+
 @keyframes distort {
     0% { opacity: 0; background-position: 0 0; }
     50% { opacity: 0.3; background-position: 0 100%; }


### PR DESCRIPTION
## Summary
- add SVG turbulence/displacement filter and tear element for ripple effect
- style tear and apply filter when ripple triggers
- schedule random ripples via JavaScript

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e09c3fa34832593e4b396b25a36e0