### PR TITLE
Extend ripple effect to entire page

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
             <feDisplacementMap id="disp" in="SourceGraphic" in2="n" xChannelSelector="R" yChannelSelector="G" scale="10"/>
         </filter>
     </svg>
+    <div class="tear" id="tear"></div>
     <div class="pip-boy">
         <div class="screen">
-            <div class="tear" id="tear"></div>
             <img id="current-image" src="" alt="Vault-Tec Instruction" style="display: none;">
             <div id="loading">Ожидайте...</div>
             <div class="scanlines"></div>

--- a/script.js
+++ b/script.js
@@ -176,7 +176,7 @@ fetch(imagesApiUrl)
 
 // Эффект ряби с использованием шумового фильтра
 (function () {
-    const screen = document.querySelector('.screen');
+    const page = document.body;
     const tear = document.getElementById('tear');
     const noise = document.getElementById('noise');
     const disp = document.getElementById('disp');
@@ -198,8 +198,8 @@ fetch(imagesApiUrl)
         const scale = Math.round(random(8, 18));
         disp.setAttribute('scale', String(scale));
 
-        screen.classList.add('ripple');
-        setTimeout(() => screen.classList.remove('ripple'), RIPPLE_MS);
+        page.classList.add('ripple');
+        setTimeout(() => page.classList.remove('ripple'), RIPPLE_MS);
 
         scheduleNext();
     }

--- a/styles.css
+++ b/styles.css
@@ -84,8 +84,9 @@ body {
 }
 
 /* Полоска-рывок и эффект ряби */
+
 .tear {
-    position: absolute;
+    position: fixed;
     left: 0;
     width: 100%;
     top: var(--tearY, 40%);
@@ -94,10 +95,10 @@ body {
     pointer-events: none;
     background: linear-gradient(to bottom, transparent 0%, rgba(255, 255, 255, 0.09) 50%, transparent 100%);
     mix-blend-mode: screen;
-    z-index: 3;
+    z-index: 1000;
 }
 
-.screen.ripple .tear {
+body.ripple .tear {
     opacity: .85;
     animation: tearShift 120ms ease-in-out 3 alternate;
 }
@@ -107,7 +108,7 @@ body {
     to { transform: translateX(6px); }
 }
 
-.screen.ripple {
+body.ripple {
     filter: url(#crt-warp);
 }
 


### PR DESCRIPTION
## Summary
- Apply CRT ripple filter to the whole document rather than only the image
- Position tear overlay globally to cover all content
- Update styles for global ripple effect

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e45c1d4708325bfd4a5035af2570b